### PR TITLE
Related ID links

### DIFF
--- a/src/README.txt
+++ b/src/README.txt
@@ -80,6 +80,9 @@ Nope, but we have a Pro addon for that called [Meta Pixie Pro](https://www.bytep
 
 == Changelog ==
 
+= 1.1 =
+* New: Related ID is now a link to edit page for related comment, post, site or user as appropriate.
+
 = 1.0.1 =
 * Fix: Expanding value for usermeta record returns postmeta value if same meta_id exists.
 

--- a/src/admin/class-meta-pixie-admin.php
+++ b/src/admin/class-meta-pixie-admin.php
@@ -436,6 +436,8 @@ class Meta_Pixie_Admin {
 			if ( is_numeric( $blog_id ) && is_multisite() ) {
 				restore_current_blog();
 			}
+		} elseif ( 'sitemeta' == $table ) {
+			$output = '<a href="' . esc_url( network_admin_url( 'site-info.php?id=' . $value ) ) . '">' . $value . '</a>';
 		}
 
 		return $output;

--- a/src/admin/class-meta-pixie-admin.php
+++ b/src/admin/class-meta-pixie-admin.php
@@ -325,7 +325,7 @@ class Meta_Pixie_Admin {
 	 * @param object $item
 	 * @param array  $options
 	 *
-	 * @return string|void
+	 * @return string
 	 */
 	public function column_meta_value( $value, $item, $options ) {
 		global $mode;
@@ -366,7 +366,7 @@ class Meta_Pixie_Admin {
 	 * @param object $item
 	 * @param array  $options
 	 *
-	 * @return string|void
+	 * @return string
 	 */
 	public function column_meta_value_row_actions( $actions, $item, $options ) {
 		global $mode;
@@ -397,6 +397,51 @@ class Meta_Pixie_Admin {
 	}
 
 	/**
+	 * Formats the related_id column for display.
+	 *
+	 * @param string $value
+	 * @param object $item
+	 * @param array  $options
+	 *
+	 * @return string
+	 */
+	public function column_related_id( $value, $item, $options ) {
+		$blog_id = empty( $_REQUEST['blog_id'] ) ? '' : sanitize_key( $_REQUEST['blog_id'] );
+		$table   = empty( $_REQUEST['table'] ) ? '' : sanitize_key( $_REQUEST['table'] );
+
+		$output = $value;
+
+		if ( in_array( $table, array( 'commentmeta', 'postmeta', 'usermeta' ) ) ) {
+			if ( is_numeric( $blog_id ) && is_multisite() ) {
+				$blog_id = (int) $blog_id;
+				switch_to_blog( $blog_id );
+			}
+
+			$output = '<a href="';
+
+			switch ( $table ) {
+				case 'commentmeta':
+					$output .= get_edit_comment_link( $value );
+					break;
+				case 'postmeta':
+					$output .= get_edit_post_link( $value );
+					break;
+				case 'usermeta':
+					$output .= get_edit_user_link( $value );
+					break;
+			}
+
+			$output .= '">' . $value . '</a>';
+
+			if ( is_numeric( $blog_id ) && is_multisite() ) {
+				restore_current_blog();
+			}
+		}
+
+		return $output;
+	}
+
+	/**
 	 * Handler for meta_pixie_column_display filter.
 	 *
 	 * @param mixed  $value
@@ -420,6 +465,9 @@ class Meta_Pixie_Admin {
 				if ( false !== strpos( $value, '!!!' ) ) {
 					$value = Meta_Pixie_Data_Format::wrap_with_error( $value, __( 'Broken data', 'meta-pixie' ) );
 				}
+				break;
+			case 'related_id':
+				$value = $this->column_related_id( $value, $item, $options );
 				break;
 		}
 

--- a/src/includes/class-meta-pixie.php
+++ b/src/includes/class-meta-pixie.php
@@ -36,7 +36,7 @@ class Meta_Pixie {
 	 */
 	public function __construct() {
 		$this->meta_pixie = 'meta-pixie';
-		$this->version    = '1.0.1';
+		$this->version    = '1.1';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/src/meta-pixie.php
+++ b/src/meta-pixie.php
@@ -5,7 +5,7 @@
  * Plugin Name:       Meta Pixie
  * Plugin URI:        https://www.bytepixie.com/meta-pixie/
  * Description:       List, filter, sort and view commentmeta, postmeta, sitemeta, termmeta and usermeta records, even serialized and base64 encoded values.
- * Version:           1.0.1
+ * Version:           1.1
  * Author:            Byte Pixie
  * Author URI:        https://www.bytepixie.com/
  * License:           GPL-2.0+


### PR DESCRIPTION
Related ID is now a link to edit page for related comment, post, site or user as appropriate.

Resolves #3