### PR TITLE
Use `get_sites` instead of `wp_get_sites` in WP 4.6+.

### DIFF
--- a/src/README.txt
+++ b/src/README.txt
@@ -3,7 +3,7 @@ Contributors: ianmjones
 Donate link: https://www.bytepixie.com/
 Tags: commentmeta, wp_commentmeta, postmeta, wp_postmeta, termmeta, wp_termmeta, sitemeta, wp_sitemeta, usermeta, wp_usermeta, metadata, admin, administration, search, sort, filter, view
 Requires at least: 3.9
-Tested up to: 4.7
+Tested up to: 4.7.1
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -82,6 +82,7 @@ Nope, but we have a Pro addon for that called [Meta Pixie Pro](https://www.bytep
 
 = 1.1 =
 * New: Related ID is now a link to edit page for related comment, post, site or user as appropriate.
+* Fix: Deprecation notice for `wp_get_sites` on WP 4.6+.
 
 = 1.0.1 =
 * Fix: Expanding value for usermeta record returns postmeta value if same meta_id exists.

--- a/src/admin/class-meta-pixie-admin.php
+++ b/src/admin/class-meta-pixie-admin.php
@@ -782,7 +782,7 @@ class Meta_Pixie_Admin {
 				$output .= '<select name="blog_id" id="blog-id-selector-top" autocomplete="off">';
 				$output .= '<option value="" disabled="disabled">&mdash; ' . _x( 'Site', 'Site to view records for', 'meta-pixie' ) . ' &mdash;</option>';
 
-				foreach ( wp_get_sites( array( 'limit' => 0 ) ) as $blog ) {
+				foreach ( $this->_get_sites( array( 'limit' => 0 ) ) as $blog ) {
 					$blog_id     = empty( $blog['blog_id'] ) ? '' : $blog['blog_id'];
 					$description = untrailingslashit( trim( $blog['domain'] ) . trim( $blog['path'] ) );
 
@@ -874,5 +874,31 @@ class Meta_Pixie_Admin {
 			';
 
 		return $content;
+	}
+
+	/**
+	 * Return an array of sites for a network or networks.
+	 *
+	 * @param array $args
+	 *
+	 * @return array
+	 */
+	private function _get_sites( $args ) {
+		global $wp_version;
+
+		$results = array();
+
+		if ( version_compare( $wp_version, '4.6-dev', '<' ) ) {
+			$results = wp_get_sites( $args );
+		} else {
+			$_sites = get_sites( $args );
+
+			foreach ( $_sites as $_site ) {
+				$_site     = get_site( $_site );
+				$results[] = $_site->to_array();
+			}
+		}
+
+		return $results;
 	}
 }


### PR DESCRIPTION
No longer get deprecation notices for `wp_get_sites` when debug log turned on.